### PR TITLE
Reduce frame max length to max Node Buffer length.

### DIFF
--- a/lib/websocket/driver/hybi.js
+++ b/lib/websocket/driver/hybi.js
@@ -66,7 +66,9 @@ var instance = {
   FRAGMENTED_OPCODES: [0, 1, 2],
   OPENING_OPCODES:    [1, 2],
 
-  MAX_LENGTH: Math.pow(2, 53) - 1,
+  // This is the maximum length of a Node buffer:
+  //   https://github.com/joyent/node/blob/master/src/smalloc.h#L40
+  MAX_LENGTH: 0x3fffffff,
   TWO_POWERS: [0, 1, 2, 3, 4, 5, 6, 7].map(function(n) { return Math.pow(2, 8 * n) }),
 
   ERRORS: {

--- a/spec/websocket/driver/hybi_spec.js
+++ b/spec/websocket/driver/hybi_spec.js
@@ -308,7 +308,7 @@ test.describe("Hybi", function() { with(this) {
       }})
 
       it("returns an error for too-large frames", function() { with(this) {
-        driver().parse([0x81, 0x7f, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        driver().parse([0x81, 0x7f, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00])
         assertEqual( "WebSocket frame length too large", error.message )
         assertEqual( [1009, "WebSocket frame length too large"], close )
         assertEqual( "closed", driver().getState() )


### PR DESCRIPTION
See faye/faye-websocket-node#26. This addresses the first issue here: receiving a large frame length (>1GB) makes the driver throw.
