### PR TITLE
Lower default max buffer length

### DIFF
--- a/lib/websocket/driver/base.js
+++ b/lib/websocket/driver/base.js
@@ -21,9 +21,9 @@ var Base = function(request, url, options) {
 util.inherits(Base, Emitter);
 
 var instance = {
-  // This is the maximum length of a Node buffer:
-  // https://github.com/joyent/node/blob/master/src/smalloc.h#L40
-  MAX_LENGTH: 0x3fffffff,
+  // This is 64MB, small enough for an average VPS to handle without
+  // crashing from process out of memory
+  MAX_LENGTH: 0x3ffffff,
 
   STATES: ['connecting', 'open', 'closing', 'closed'],
 


### PR DESCRIPTION
Testing on a VPS with 1GB of RAM and 1GB of swap, testing messages of arbitrarily large size, the server crashed from running out of memory at around 300MB.

Knowing this, 64MB seems like a reasonably conservative maximum. It's plenty large enough to fit anything you'd normally want to use WebSocket for, and anyone who needs it higher and has a server with enough RAM to handle it can manually increase the setting from the default.
