### PR TITLE
StreamReader: Don't hang on to fully read buffers

### DIFF
--- a/lib/websocket/driver/hybi/stream_reader.js
+++ b/lib/websocket/driver/hybi/stream_reader.js
@@ -40,6 +40,13 @@ StreamReader.prototype._readBuffer = function(length) {
   queue.splice(0, i-1);
   this._cursor = (i === 1 ? this._cursor : 0) + size;
 
+  // If we've fully read the last chunk we were reading, stop referencing the
+  // Buffer now rather than later.
+  if (queue.length && this._cursor === queue[0].length) {
+    queue.shift();
+    this._cursor = 0;
+  }
+
   return buffer;
 };
 


### PR DESCRIPTION
We have a socket leak in our app, and we noticed that all the sockets (despite being inactive and fully parsed) were hanging on to a buffer in queue[0].  Now, on the one hand, it was kind of nice to make the leak more obvious by inflating it :)  but it should probably be fixed.
