### PR TITLE
driver.close() before driver.start() should close

### DIFF
--- a/lib/websocket/driver/hybi.js
+++ b/lib/websocket/driver/hybi.js
@@ -209,7 +209,7 @@ var instance = {
     reason = reason || '';
     code   = code   || this.ERRORS.normal_closure;
 
-    if (this.readyState === 0) {
+    if (this.readyState <= 0) {
       this.readyState = 3;
       this.emit('close', new Base.CloseEvent(code, reason));
       return true;

--- a/spec/websocket/driver/client_spec.js
+++ b/spec/websocket/driver/client_spec.js
@@ -50,6 +50,14 @@ test.describe("Client", function() { with(this) {
       assertEqual( null, driver().getState() )
     }})
 
+    describe("close", function() { with(this) {
+      it("changes the state to closed", function() { with(this) {
+        driver().close()
+        assertEqual( "closed", driver().getState() )
+        assertEqual( [1000, ''], close )
+      }})
+    }})
+
     describe("start", function() { with(this) {
       it("writes the handshake request to the socket", function() { with(this) {
         expect(driver().io, "emit").given("data", buffer(


### PR DESCRIPTION
If you call `close` on the driver before calling `start`, it's currently ignored.  You might think this is just a matter of "don't use the API that way". But when it's being run from Faye WebSocket.Client, you don't really have a choice: `start` is invoked automatically and asynchronously when the TCP connection succeeds, and you definitely might want to change your mind and close the socket sometime between construction and TCP success.  I will create a PR for faye/faye-websocket-node as well adding a test (which depends on this PR).
