### PR TITLE
proxy should emit 'close' when it's done

### DIFF
--- a/lib/websocket/driver/proxy.js
+++ b/lib/websocket/driver/proxy.js
@@ -79,6 +79,7 @@ var instance = {
       this.emit('error', new Error(message));
     }
     this.end();
+    this.emit('close');
     return !this._paused;
   },
 

--- a/spec/websocket/driver/client_spec.js
+++ b/spec/websocket/driver/client_spec.js
@@ -180,12 +180,14 @@ test.describe("Client", function() { with(this) {
 
       it("emits a 'connect' event when the proxy connects", function() { with(this) {
         expect(proxy, "emit").given("connect")
+        expect(proxy, "emit").given("close")
         expect(proxy, "emit").given("end")
         proxy.write(new Buffer("HTTP/1.1 200 OK\r\n\r\n"))
       }})
 
       it("emits an 'error' event if the proxy does not connect", function() { with(this) {
         expect(proxy, "emit").given("error", objectIncluding({message: "Can't establish a connection to the server at ws://www.example.com/socket"}))
+        expect(proxy, "emit").given("close")
         expect(proxy, "emit").given("end")
         proxy.write(new Buffer("HTTP/1.1 403 Forbidden\r\n\r\n"))
       }})


### PR DESCRIPTION
This will cause any stream piped into it to stop piping into it. (It's
the only way to unpipe a Node 0.8 Streams1-style pipe.)

This change allows you to remove the empty "stream.on('data')" in
faye-websocket.
