### PR TITLE
Add pong command

### DIFF
--- a/lib/websocket/driver/base.js
+++ b/lib/websocket/driver/base.js
@@ -94,6 +94,10 @@ var instance = {
     return false;
   },
 
+  pong: function() {
+      return false;
+  },
+
   close: function(reason, code) {
     if (this.readyState !== 1) return false;
     this.readyState = 3;

--- a/lib/websocket/driver/hybi.js
+++ b/lib/websocket/driver/hybi.js
@@ -171,6 +171,7 @@ var instance = {
 
   pong: function(message) {
       if (this.readyState > 1) return false;
+      message = message ||'';
       return this.frame(message, 'pong');
   },
 

--- a/lib/websocket/driver/hybi.js
+++ b/lib/websocket/driver/hybi.js
@@ -169,6 +169,11 @@ var instance = {
     return this.frame(message, 'ping');
   },
 
+  pong: function(message) {
+      if (this.readyState > 1) return false;
+      return this.frame(message, 'pong');
+  },
+
   close: function(reason, code) {
     reason = reason || '';
     code   = code   || this.ERRORS.normal_closure;

--- a/spec/websocket/driver/hybi_spec.js
+++ b/spec/websocket/driver/hybi_spec.js
@@ -418,6 +418,17 @@ test.describe("Hybi", function() { with(this) {
       }})
     }})
 
+    describe("pong", function() { with(this) {
+      it("writes a pong frame to the socket", function() { with(this) {
+        driver().pong("mic check")
+        assertEqual([0x8a, 0x09, 0x6d, 0x69, 0x63, 0x20, 0x63, 0x68, 0x65, 0x63, 0x6b], collector().bytes)
+      }})
+
+      it("returns true", function() { with(this) {
+        assertEqual(true, driver().pong())
+      }})
+    }})
+
     describe("close", function() { with(this) {
       it("writes a close frame to the socket", function() { with(this) {
         driver().close("<%= reasons %>", 1003)
@@ -491,6 +502,17 @@ test.describe("Hybi", function() { with(this) {
       }})
     }})
 
+    describe("pong", function() { with(this) {
+      it("does not write to the socket", function() { with(this) {
+        expect(driver().io, "emit").exactly(0)
+        driver().pong()
+      }})
+
+      it("returns false", function() { with(this) {
+        assertEqual( false, driver().pong() )
+      }})
+    }})
+
     describe("close", function() { with(this) {
       it("does not write to the socket", function() { with(this) {
         expect(driver().io, "emit").exactly(0)
@@ -543,6 +565,17 @@ test.describe("Hybi", function() { with(this) {
 
       it("returns false", function() { with(this) {
         assertEqual( false, driver().ping() )
+      }})
+    }})
+
+    describe("pong", function() { with(this) {
+      it("does not write to the socket", function() { with(this) {
+        expect(driver().io, "emit").exactly(0)
+        driver().pong()
+      }})
+
+      it("returns false", function() { with(this) {
+        assertEqual( false, driver().pong() )
       }})
     }})
 

--- a/spec/websocket/driver/hybi_spec.js
+++ b/spec/websocket/driver/hybi_spec.js
@@ -160,6 +160,30 @@ test.describe("Hybi", function() { with(this) {
       }})
     }})
 
+    describe("pong", function() { with(this) {
+        it("does not write to the socket", function() { with(this) {
+            expect(driver().io, "emit").exactly(0)
+            driver().pong()
+        }})
+
+        it("returns true", function() { with(this) {
+            assertEqual( true, driver().pong() )
+        }})
+
+        it("queues the pong until the handshake has been sent", function() { with(this) {
+            expect(driver().io, "emit").given("data", buffer(
+                "HTTP/1.1 101 Switching Protocols\r\n" +
+                "Upgrade: websocket\r\n" +
+                "Connection: Upgrade\r\n" +
+                "Sec-WebSocket-Accept: JdiiuafpBKRqD7eol0y4vJDTsTs=\r\n" +
+                "\r\n"))
+            expect(driver().io, "emit").given("data", buffer([0x8a, 0]))
+
+            driver().pong()
+            driver().start()
+        }})
+    }})
+
     describe("close", function() { with(this) {
       it("does not write anything to the socket", function() { with(this) {
         expect(driver().io, "emit").exactly(0)


### PR DESCRIPTION
This implements a 'pong' method to `hybi.js` that always returns `false` if invoked by a driver running an _older_ draft. This allows clients to send unidirectional heartbeats, as stated by [RFC 6455, page 37](https://tools.ietf.org/html/rfc6455#page-37)