### PR TITLE
Prevent buffers from being mutated when sending frames.

### DIFF
--- a/lib/websocket/driver/hybi.js
+++ b/lib/websocket/driver/hybi.js
@@ -192,7 +192,7 @@ var instance = {
     if (this.readyState <= 0) return this._queue([buffer, type, code]);
     if (this.readyState > 2) return false;
 
-    if (buffer instanceof Array)    buffer = new Buffer(buffer);
+    if (Buffer.isBuffer(buffer) || buffer instanceof Array) buffer = new Buffer(buffer);
     if (typeof buffer === 'number') buffer = buffer.toString();
 
     var message = new Message(),

--- a/spec/websocket/driver/hybi_spec.js
+++ b/spec/websocket/driver/hybi_spec.js
@@ -522,8 +522,15 @@ test.describe("Hybi", function() { with(this) {
   describe("when masking is required", function() { with(this) {
     before(function() {
       this.options().requireMasking = true
+      this.options().masking = true
       this.driver().start()
     })
+
+    it("does not mutate the input if it is a buffer", function() { with(this) {
+      var buf = new Buffer([0x48, 0x65, 0x6c]), str = buf.toString('hex')
+      driver().frame(buf)
+      assertEqual(str, buf.toString('hex'))
+    }})
 
     it("does not emit a message", function() { with(this) {
       driver().parse([0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f])


### PR DESCRIPTION
Right now when a buffer is sent with the public `send` method, it is changes in place after the [mask is applied](https://github.com/faye/websocket-driver-node/blob/2be829546b462aa7d552214e17d6f3e42b6a4bd0/lib/websocket/driver/hybi.js#L269).

Here is a test case:

```js
'use strict';

const WebSocket = require('faye-websocket');
const assert = require('assert');
const http = require('http');

const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
const server = http.createServer();

server.on('upgrade', (req, socket, head) => {
  const ws = new WebSocket(req, socket, head);

  ws.on('message', (event) => {
    assert.deepStrictEqual(event.data, buf);
    ws.close();
    server.close();
  });
});

server.on('listening', () => {
  const ws = new WebSocket.Client('ws://localhost:8080');

  ws.on('open', () => ws.send(buf));
});

server.listen(8080);
```

This patch changes this behavior by working on a copy of the original buffer. 