### PR TITLE
Update http-parer-js minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 , "files"           : ["lib"]
 , "main"            : "./lib/websocket/driver"
 
-, "dependencies"    : { "http-parser-js": ">=0.4.0"
+, "dependencies"    : { "http-parser-js": ">=0.4.6"
                       , "websocket-extensions": ">=0.1.1"
                       }
 , "devDependencies" : { "jstest": "*"


### PR DESCRIPTION
The version 0.4.5 of http-parer-js contains a file with special characters that cannot be parsed by other packages sometimes.
It's safer to ask minimum for the version 0.4.6 so no one will get this kind of error.