### PR TITLE
Fix crash when request headers include websocket version, but not key

### DIFF
--- a/lib/websocket/driver/server.js
+++ b/lib/websocket/driver/server.js
@@ -103,7 +103,7 @@ Server.getDriverClass = function(request) {
     return null;
 
   if (typeof version === 'string' || typeof key === 'string')
-    return (version === '13' && key.length > 0) ? Hybi : null;
+    return (version && key && version.split(/ *, */).indexOf('13') < 0) ? Hybi : null;
 
   if (typeof origin !== 'string' || origin.length === 0)
     return null;


### PR DESCRIPTION
[Also adds support for `Sec-WebSocket-Version` to be a comma separated list of versions](https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17#section-4.4)