### PR TITLE
handling match in empty string

### DIFF
--- a/lib/websocket/http_parser.js
+++ b/lib/websocket/http_parser.js
@@ -96,9 +96,11 @@ HttpParser.METHODS = {
   32: 'UNLINK'
 };
 
-var VERSION = (process.version || '')
-              .match(/[0-9]+/g)
-              .map(function(n) { return parseInt(n, 10) });
+var VERSION = process.version
+  ? process.version
+      .match(/[0-9]+/g)
+      .map(function(n) { return parseInt(n, 10) })
+  : [];
 
 if (VERSION[0] === 0 && VERSION[1] === 12) {
   HttpParser.METHODS[16] = 'REPORT';


### PR DESCRIPTION
The previous fix (#26) wasn't handling the return of the match function, witch is null when the string is empty.