### PR TITLE
[Security] Bump websocket-extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
           "dependencies": {
                     "http-parser-js": ">=0.5.1",
                     "safe-buffer": ">=5.1.0",
-                    "websocket-extensions": ">=0.1.1"
+                    "websocket-extensions": ">=0.1.4"
           },
           "devDependencies": {
                     "jstest": "*",


### PR DESCRIPTION
We received a security alert for the `firebase` npm module which includes this downstream. Pre 1.0.4 versions of this package are at-risk of a Denial of service attack (dependable told us this):

![image](https://user-images.githubusercontent.com/3408480/83973277-434db580-a8b3-11ea-9cd6-98fa32d4d1a1.png)
