### PR TITLE
Add `hasOwnPropertyCheck` to validateOptions

### DIFF
--- a/lib/websocket/driver/base.js
+++ b/lib/websocket/driver/base.js
@@ -37,7 +37,7 @@ Base.isWebSocket = function(request) {
 
 Base.validateOptions = function(options, validKeys) {
   for (var key in options) {
-    if (validKeys.indexOf(key) < 0)
+    if (options.hasOwnProperty(key) && validKeys.indexOf(key) < 0)
       throw new Error('Unrecognized option: ' + key);
   }
 };


### PR DESCRIPTION
This fixes https://github.com/firebase/firebase-js-sdk/issues/4276. If a user extends the object prototype, any key from the prototype chain will get validated against the allowed set of options for WebSocketDriver. This fails the validation and breaks the Firebase Database SDK.